### PR TITLE
Check get cache load type assertion

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -28,7 +28,6 @@ package groupcache
 
 import (
 	"errors"
-	"fmt"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -301,10 +300,8 @@ func (g *Group) load(ctx Context, key string, dest Sink) (value ByteView, destPo
 		// 1: fn()
 		// 2: loadGroup.Do("key", fn)
 		// 2: fn()
-		// TODO LOGS IN VARIOUS CASES
 		if value, cacheHit := g.lookupCache(key); cacheHit {
 			g.Stats.CacheHits.Add(1)
-			fmt.Println("GROUPCACHE/GROUP.LOAD - Returning value from lookupCache")
 			return value, nil
 		}
 		g.Stats.LoadsDeduped.Add(1)
@@ -314,7 +311,6 @@ func (g *Group) load(ctx Context, key string, dest Sink) (value ByteView, destPo
 			value, err = g.getFromPeer(ctx, peer, key)
 			if err == nil {
 				g.Stats.PeerLoads.Add(1)
-				fmt.Println("GROUPCACHE/GROUP.LOAD - Returning value from getFromPeer")
 				return value, nil
 			}
 			g.Stats.PeerErrors.Add(1)
@@ -331,7 +327,6 @@ func (g *Group) load(ctx Context, key string, dest Sink) (value ByteView, destPo
 		g.Stats.LocalLoads.Add(1)
 		destPopulated = true // only one caller of load gets this return value
 		g.populateCache(key, value, &g.mainCache)
-		fmt.Println("GROUPCACHE/GROUP.LOAD - Returning value from getLocally")
 		return value, nil
 	})
 	if err == nil {


### PR DESCRIPTION
It's possible for this assertion to panic, although I've not been able to reproduce it. This should allow those cases not to crash and propagate their errors upwards.

This also adds some explicit tests for TruncatingByteSlices using SetBytes.